### PR TITLE
Accel/decel cornercases

### DIFF
--- a/lib/event-emit.js
+++ b/lib/event-emit.js
@@ -130,6 +130,20 @@ function EmitterPlace(geojson, speedmode) {
         speed: speeds[index]
       });
     }
+    // End of the trace
+    if (i > times[times.length-1]) {
+      index = times.length-1;
+      if (last.coords[0] === coords[index][0] &&
+        last.coords[1] === coords[index][1]) {
+        return null;
+      } else {
+        return locationEvent({
+          next: coords[index],
+          last: last,
+          speed: speeds[index]
+        });
+      }
+    }
     // Need to place this in times array to find surrounding points
     allTimes = times.slice(0);
     allTimes.push(i);

--- a/lib/route.js
+++ b/lib/route.js
@@ -238,7 +238,10 @@ function interpolateAccelDecel(routeSteps, rate) {
  */
 function Place(thisDist, thisSpeed, nextSpeed, rate) {
   var changeSegment = util.changeSegment(thisSpeed, nextSpeed, rate);
-  if (changeSegment.meters > thisDist) throw new Error('cannot change speed within step constraints');
+  while (changeSegment.meters > thisDist) {
+    rate++;
+    changeSegment = util.changeSegment(thisSpeed, nextSpeed, rate);
+  }
   var dists = [0, thisDist - changeSegment.meters, thisDist];
   var times = [0];
   times.push(util.timeFromSpeed(thisSpeed, thisDist - changeSegment.meters));

--- a/test/event-emit.test.js
+++ b/test/event-emit.test.js
@@ -81,6 +81,29 @@ test('emit.next', function(t) {
   t.end();
 });
 
+test('emit.next acceldecel', function(assert) {
+  var geojson = route(JSON.parse(JSON.stringify(require('./fixtures/garage.v5'))), { spacing: 'acceldecel' });
+  var times = geojson.properties.coordinateProperties.times;
+  var lastTime = times[times.length-1];
+  var emitter = new Emitter(geojson, 2000);
+
+  var ev;
+  var num = 0;
+  while (ev = emitter.next()) {
+    assert.equal(ev.coords.length, 2, 'event ' + num + ' coords');
+    assert.equal(typeof ev.bearing, 'number', 'event ' + num + ' bearing');
+    assert.equal(typeof ev.speed, 'number', 'event ' + num + ' speed');
+    if (num === 0) {
+      assert.deepEqual(ev.speedchange, undefined, 'event ' + num + ' speedchange');
+    } else {
+      assert.equal(typeof ev.speedchange, 'number', 'event ' + num + ' speedchange');
+    }
+    num++;
+  }
+  assert.deepEqual(ev, null, 'last event is null');
+  assert.end();
+});
+
 test('speed placer', function(t) {
   var garage = JSON.parse(JSON.stringify(require('./fixtures/garage.v5')));
   var garageSteps = garage.routes[0].legs[0].steps;

--- a/test/event-emit.test.js
+++ b/test/event-emit.test.js
@@ -83,14 +83,12 @@ test('emit.next', function(t) {
 
 test('emit.next acceldecel', function(assert) {
   var geojson = route(JSON.parse(JSON.stringify(require('./fixtures/garage.v5'))), { spacing: 'acceldecel' });
-  var times = geojson.properties.coordinateProperties.times;
-  var lastTime = times[times.length-1];
   var emitter = new Emitter(geojson, 2000);
 
-  var ev;
+  var ev = emitter.next();
   var num = 0;
   // Request events until the last event (indicated by `null`) is reached.
-  while (ev = emitter.next()) {
+  while (ev) {
     assert.equal(ev.coords.length, 2, 'event ' + num + ' coords');
     assert.equal(typeof ev.bearing, 'number', 'event ' + num + ' bearing');
     assert.equal(typeof ev.speed, 'number', 'event ' + num + ' speed');
@@ -100,6 +98,7 @@ test('emit.next acceldecel', function(assert) {
       assert.equal(typeof ev.speedchange, 'number', 'event ' + num + ' speedchange');
     }
     num++;
+    ev = emitter.next();
   }
   assert.deepEqual(ev, null, 'last event is null');
   assert.end();

--- a/test/event-emit.test.js
+++ b/test/event-emit.test.js
@@ -89,6 +89,7 @@ test('emit.next acceldecel', function(assert) {
 
   var ev;
   var num = 0;
+  // Request events until the last event (indicated by `null`) is reached.
   while (ev = emitter.next()) {
     assert.equal(ev.coords.length, 2, 'event ' + num + ' coords');
     assert.equal(typeof ev.bearing, 'number', 'event ' + num + ' bearing');

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -272,11 +272,6 @@ test('place datapoints [garage]', function(t) {
     assert.equal(thisSpeed, 4.239076929829525);
     assert.equal(nextSpeed, 28.482824403352883);
     assert.equal(thisDist, 24.492444483459483);
-    
-    assert.throws(
-      function() {
-        new Place(thisDist, thisSpeed, nextSpeed, 4);
-      }, /cannot change speed within step constraints/);
 
     var place = new Place(thisDist, thisSpeed, nextSpeed, 5);
 
@@ -296,6 +291,11 @@ test('place datapoints [garage]', function(t) {
     assert.deepEqual(place.seconds(0), { distance: 0, speed: 4.239076929829525 });
     assert.deepEqual(place.seconds(2.085984521938736), { distance: 2.4562913508144355, speed: 4.239076929829525 });
     assert.deepEqual(place.seconds(6.934734016643407), { distance: 24.49244448345948, speed: 28.48282440335288 });
+
+    // This call will adjust the specified rate (1) until it can be achieved (5)
+    var adjustedPlace = new Place(thisDist, thisSpeed, nextSpeed, 1);
+    assert.deepEqual(place.dists, adjustedPlace.dists, 'adjusts rate until possible');
+    assert.deepEqual(place.times, adjustedPlace.times, 'adjusts rate until possible');
 
     assert.end();
   });


### PR DESCRIPTION
Smooths over 2 corner cases we've run into using `acceldecel` mode:

**End of time**

At the end of timeline sometimes the requested interval would be beyond the final time value. In this case the time insertion/sort method would fail ending in :broken_heart:. Remedy: use last time value, and then return null.

Adds test for this scenario as well.

**Can't stop! Won't stop!**

Placing a point at the constant rate would sometimes fail on very short segments as there wasn't enough room to decelerate at that rate. Remedy: keep trying rates (incrementing by 1) until we're using a rate that works.

cc @emilymcafee @emilymdubois 
