### PR TITLE
Sketch of supporting acceldecel mode on v4

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -8,6 +8,7 @@ route.interpolateConstant = interpolateConstant;
 route.interpolateAccelDecel = interpolateAccelDecel;
 route.buildTrace = buildTrace;
 route.Place = Place;
+route.getSteps = getSteps;
 
 /**
  * Turn a Mapbox Directions API response into timestamped GeoJSON
@@ -21,9 +22,7 @@ route.Place = Place;
  * starting at 0.
  */
 function route(directions, options) {
-  var v = util.version(directions);
   var spacing = (options && options.spacing) ? options.spacing : 'constant';
-  if (v === 'v4' && spacing === 'acceldecel') throw new Error('v4 directions are only compatible with constant speeds');
   var steps = getSteps(directions);
   return buildTrace(steps, { spacing: spacing });
 }
@@ -36,14 +35,40 @@ function route(directions, options) {
  */
 function getSteps(directions) {
   var v = util.version(directions);
+  var steps = [];
   if (v === 'v4') {
-    return directions.routes;
+    var route = directions.routes[0];
+    var routeSteps = route.steps.slice(0);
+    var prev = routeSteps.shift();
+    var next = routeSteps.shift();
+    var step = { geometry: { type: 'LineString', coordinates:[] } };
+    for (var a = 0; a < route.geometry.coordinates.length; a++) {
+      if (route.geometry.coordinates[a][0] === next.maneuver.location.coordinates[0] &&
+        route.geometry.coordinates[a][1] === next.maneuver.location.coordinates[1]) {
+        // Finish previous step
+        step.geometry.coordinates.push(route.geometry.coordinates[a]);
+        step.duration = prev.duration;
+        step.distance = prev.distance;
+        steps.push(step);
+        // Start next step
+        step = { geometry: { type: 'LineString', coordinates:[] } };
+        step.geometry.coordinates.push(route.geometry.coordinates[a]);
+        // Set next maneuver
+        prev = next;
+        next = routeSteps.shift();
+      } else {
+        step.geometry.coordinates.push(route.geometry.coordinates[a]);
+      }
+    }
+    // Mimic arrival step
+    steps.push({ distance:0, duration:0, geometry: { type: 'LineString', coordinates:[] } });
+    return steps;
   }
   if (v === 'v5') {
     if (directions.routes[0].legs.length === 1) {
       steps = directions.routes[0].legs[0].steps;
     } else {
-      var steps = [];
+      steps = [];
       for (var i = 0; i < directions.routes[0].legs.length; i++) {
         steps = steps.concat(directions.routes[0].legs[i].steps); 
       }

--- a/test/route.getSteps.test.js
+++ b/test/route.getSteps.test.js
@@ -1,0 +1,30 @@
+var tape = require('tape');
+var route = require('../lib/route');
+
+tape('route.getSteps v4', function(assert) {
+  var garage = JSON.parse(JSON.stringify(require('./fixtures/garage.v4')));
+  var steps = route.getSteps(garage);
+  assert.deepEqual(steps.length, 4, 'creates 4 steps');
+  // Don't consider the last "arrival" step
+  garage.routes[0].steps.slice(0,-1).forEach(function(step, i) {
+    assert.deepEqual(steps[i].distance, step.distance, 'step ' + i + ' distance = ' + steps[i].distance);
+    assert.deepEqual(steps[i].duration, step.duration, 'step ' + i + ' duration = ' + steps[i].duration);
+  });
+  assert.deepEqual(steps.reduce(function(memo, step) {
+    memo += step.geometry.coordinates.length;
+    return memo;
+  }, 0), 7, 'has 7 geom coordinates');
+  assert.end();
+});
+
+tape('route.getSteps v5', function(assert) {
+  var garage = JSON.parse(JSON.stringify(require('./fixtures/garage.v5')));
+  var steps = route.getSteps(garage);
+  assert.deepEqual(steps.length, 2, 'creates 2 steps');
+  assert.deepEqual(steps.reduce(function(memo, step) {
+    memo += step.geometry.coordinates.length;
+    return memo;
+  }, 0), 6, 'has 6 geom coordinates');
+  assert.end();
+});
+

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -50,7 +50,7 @@ test('route', function(t) {
       [ -77.032674, 38.913151 ],
       [ -77.032669, 38.913356 ]
     ]);
-    assert.deepEqual(geojson.properties.coordinateProperties.times, [ 0, 4828, 6469, 22824, 29000 ]);
+    assert.deepEqual(geojson.properties.coordinateProperties.times, [ 0, 16420, 22000, 29000, 32000 ]);
     assert.end();
   });
 

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -42,13 +42,6 @@ test('buildTrace', function(t) {
 test('route', function(t) {
   t.test('garage (v4)', function(assert) {
     var garage = JSON.parse(JSON.stringify(require('./fixtures/garage.v4')));
-    assert.throws(function() { route(garage, { spacing: 'acceldecel' }); }, /v4 directions are only compatible with constant speeds/);
-    assert.doesNotThrow(function() { route (garage, { spacing: 'constant'  }); });
-    assert.end();
-  });
-
-  t.test('garage (v4)', function(assert) {
-    var garage = JSON.parse(JSON.stringify(require('./fixtures/garage.v4')));
     var geojson = route(garage);
     assert.deepEqual(geojson.geometry.coordinates, [
       [ -77.032394, 38.912609 ],


### PR DESCRIPTION
Slices up the v4 routes linestring into separate steps with their own duration/distance values. Enables `acceldecel` mode on v4.

cc @emilymdubois 
