### PR TITLE
Adds acceldecel handling for Locator

### DIFF
--- a/lib/locator.js
+++ b/lib/locator.js
@@ -1,8 +1,12 @@
+var route = require('./route');
 var turfAlong = require('turf-along');
 var turfDistance = require('turf-distance');
 var turfLinestring = require('turf-linestring');
 var turfPoint = require('turf-point');
 var util = require('./util');
+
+var getSteps = route.getSteps;
+var interpolateAccelDecel = route.interpolateAccelDecel;
 
 module.exports = Locator;
 
@@ -13,27 +17,47 @@ module.exports = Locator;
  * @class
  * @param {Object} directions Response from Mapbox Directions API.
  */
-function Locator(directions) {
-  var version = util.version(directions);
+function Locator(directions, options) {
+  var spacing = (options && options.spacing) ? options.spacing : 'constant';
   var coordinates = [];
   var times = [];
   var timeCounter = 0;
-  if (version === 'v5') {
-    for (var i = 0; i < directions.routes[0].legs[0].steps.length; i++) {
-      timeCounter = timeCounter + directions.routes[0].legs[0].steps[i].duration * 1000;
-      times.push(timeCounter);
-      coordinates.push(directions.routes[0].legs[0].steps[i].maneuver.location);
-    }
-  } else if (version === 'v4') {
-    for (i = 0; i < directions.routes[0].steps.length; i++) {
-      timeCounter = timeCounter + directions.routes[0].steps[i].duration * 1000;
-      times.push(timeCounter);
-      coordinates.push(directions.routes[0].steps[i].maneuver.location.coordinates);
-    }
-  }
+  var i;
 
-  times.unshift(0); // adds a lower bounding value to times array
-  times.pop(); // removes the arrival step where duration = 0
+  // If in speedmode, generate coordinate <=> time mappings for maneuvers
+  // using the interpolateAccelDecel() function.
+  // If not in speedmode, generate coordinate <=> time mappings
+  // using the API response.
+  if (spacing === 'acceldecel') {
+    var steps = getSteps(directions);
+    var interpolate = interpolateAccelDecel(steps, 5);
+    coordinates.push(interpolate[0].geometry.coordinates[0]);
+    times.push(0);
+    for (i = 0; i < interpolate.length; i++) {
+      var last = interpolate[i].geometry.coordinates.length - 1;
+      var coord = interpolate[i].geometry.coordinates[last];
+      timeCounter += interpolate[i].properties.coordinateProperties.times[last];
+      coordinates.push(coord);
+      times.push(timeCounter);
+    }
+  } else {
+    var version = util.version(directions);
+    if (version === 'v5') {
+      for (i = 0; i < directions.routes[0].legs[0].steps.length; i++) {
+        timeCounter = timeCounter + directions.routes[0].legs[0].steps[i].duration * 1000;
+        times.push(timeCounter);
+        coordinates.push(directions.routes[0].legs[0].steps[i].maneuver.location);
+      }
+    } else if (version === 'v4') {
+      for (i = 0; i < directions.routes[0].steps.length; i++) {
+        timeCounter = timeCounter + directions.routes[0].steps[i].duration * 1000;
+        times.push(timeCounter);
+        coordinates.push(directions.routes[0].steps[i].maneuver.location.coordinates);
+      }
+    }
+    times.unshift(0); // adds a lower bounding value to times array
+    times.pop(); // removes the arrival step where duration = 0
+  }
 
   /**
    * Find the current Mapbox Directions API step (see 

--- a/lib/locator.js
+++ b/lib/locator.js
@@ -30,7 +30,7 @@ function Locator(directions, options) {
   // using the API response.
   if (spacing === 'acceldecel') {
     var steps = getSteps(directions);
-    var interpolate = interpolateAccelDecel(steps, 5);
+    var interpolate = interpolateAccelDecel(steps);
     coordinates.push(interpolate[0].geometry.coordinates[0]);
     times.push(0);
     for (i = 0; i < interpolate.length; i++) {

--- a/lib/locator.js
+++ b/lib/locator.js
@@ -60,6 +60,20 @@ function Locator(directions, options) {
   }
 
   /**
+   * Get times (milliseconds) and coordinates for the maneuvers
+   * along a route.
+   *
+   * @returns {Object} result Object with `times` and `coordinates` arrays
+   */
+  this.maneuvers = function() {
+    var result = {
+      'times': times,
+      'coordinates': coordinates
+    };
+    return result;
+  };
+
+  /**
    * Find the current Mapbox Directions API step (see 
    * https://www.mapbox.com/api-documentation/#retrieve-directions) given a time
    * along the route.

--- a/lib/route.js
+++ b/lib/route.js
@@ -113,7 +113,7 @@ function buildTrace(routeSteps, options) {
     routeSteps = routeSteps.map(function(routeStep) { return interpolateConstant(routeStep); });
     break;
   case 'acceldecel':
-    routeSteps = interpolateAccelDecel(routeSteps, 5);
+    routeSteps = interpolateAccelDecel(routeSteps);
     break;
   default:
     throw new Error('options.spacing must be one of constant or acceldecel.');
@@ -172,14 +172,17 @@ function buildTrace(routeSteps, options) {
  * @returns {Object} GeoJSON LineString with coordinateProperties.times
  * timestamps (ms) for each coordinate.
  */
-function interpolateAccelDecel(routeSteps, rate) {
+function interpolateAccelDecel(routeSteps) {
   var steps = [];
   for (var i = 0; i < routeSteps.length - 1; i++) {
     var thisSpeed = util.speed(routeSteps[i].distance, routeSteps[i].duration);
     var nextSpeed = routeSteps[i + 1] ? util.speed(routeSteps[i + 1].distance, routeSteps[i + 1].duration) : 0;
     var thisDist = routeSteps[i].distance;
 
+    // Rate (absolute value) at which to accelerate and decelerate,
+    // in kilometers/hour per second
     // If rate doesn't fit in this step, figure out something that does
+    var rate = 5;
     var constraint = Math.abs(thisSpeed - nextSpeed)/routeSteps[i].duration;
     if (constraint >= rate) rate = Math.ceil(constraint) + 1;
 

--- a/lib/route.js
+++ b/lib/route.js
@@ -73,12 +73,15 @@ function getSteps(directions) {
         steps = steps.concat(directions.routes[0].legs[i].steps); 
       }
     }
+
     // If a LineString feature contains less than 2 coordinate pairs, drop it
     for (var j = 0; j < steps.length; j++) {
       if (steps[j].geometry.coordinates.length < 2 && steps[j].geometry.type === 'LineString') {
+        console.log('LineString with 1 coordinate pair ([' + steps[j].geometry.coordinates + ']) is invalid.');
         steps.splice(j, 1);
       }
     }
+
     return steps;
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,12 @@ Generate the location of an event, in terms of step number or coordinates, given
 
 -   `directions` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** Response from Mapbox Directions API.
 
+#### Locator.maneuvers
+
+Get times (milliseconds) and coordinates for the maneuvers along the route.
+
+Returns **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** Object with `times` and `coordinates` arrays for maneuvers along route.
+
 #### Locator.step
 
 Find the current [Mapbox Directions API step](https://www.mapbox.com/api-documentation/#retrieve-directions) given a time along the route.

--- a/test/locator.test.js
+++ b/test/locator.test.js
@@ -34,6 +34,21 @@ test('step v5', function (assert) {
   assert.end();
 });
 
+test('step v5 in accdeldecel mode', function (assert) {
+  var geojson = JSON.parse(JSON.stringify(require('./fixtures/rmnp.v5.json')));
+  var locator = new Locator(geojson, {'spacing': 'acceldecel'});
+  assert.equal(locator.step(0), 0, 'Time 0 should correspond to step 0');
+  assert.equal(locator.step(46317), 0, 'Time 46800 should correspond to step 0');
+  assert.equal(locator.step(46318), 1, 'Time 47800 should correspond to step 1');
+  assert.equal(locator.step(46319), 1, 'Time 48800 should correspond to step 1');
+  assert.equal(locator.step(219140), 1, 'Time 219700 should correspond to step 1');
+  assert.equal(locator.step(219141), 2, 'Time 220700 should correspond to step 2');
+  assert.equal(locator.step(219142), 2, 'Time 230700 should correspond to step 2');
+  assert.equal(locator.step(259743), 2, 'Time 230700 should correspond to step 2');
+  assert.equal(locator.step(259744), 3, 'Time 257500 should correspond to step 3');
+  assert.end();
+});
+
 test('coords v4', function (assert) {
   var geojson = JSON.parse(JSON.stringify(require('./fixtures/rmnp.v4.json')));
   var locator = new Locator(geojson);
@@ -95,5 +110,34 @@ test('coords v5', function (assert) {
             locator.coords(257399).geometry.coordinates[1] < step2lat && locator.coords(257399).geometry.coordinates[1] > step3lat, 'Time 257399 coordinates should fall into step 2');
   assert.ok(Math.abs(locator.coords(257400).geometry.coordinates[0] - step3lon) < 0.00001 &&
             Math.abs(locator.coords(257400).geometry.coordinates[1] - step3lat) < 0.00001, 'Time 257400 coordinates should correspond to 3rd coordinates');
+  assert.end();
+});
+
+test('coords v5 in acceldecel mode', function (assert) {
+  var geojson = JSON.parse(JSON.stringify(require('./fixtures/rmnp.v5.json')));
+  var locator = new Locator(geojson, {'spacing': 'acceldecel'});
+  var step0lon = geojson.routes[0].legs[0].steps[0].maneuver.location[0];
+  var step0lat = geojson.routes[0].legs[0].steps[0].maneuver.location[1];
+  var step1lon = geojson.routes[0].legs[0].steps[1].maneuver.location[0];
+  var step1lat = geojson.routes[0].legs[0].steps[1].maneuver.location[1];
+  var step2lon = geojson.routes[0].legs[0].steps[2].maneuver.location[0];
+  var step2lat = geojson.routes[0].legs[0].steps[2].maneuver.location[1];
+  var step3lon = geojson.routes[0].legs[0].steps[3].maneuver.location[0];
+  var step3lat = geojson.routes[0].legs[0].steps[3].maneuver.location[1];
+
+  assert.ok(Math.abs(locator.coords(0).geometry.coordinates[0] - step0lon) < 0.00001 &&
+            Math.abs(locator.coords(0).geometry.coordinates[1] - step0lat) < 0.00001, 'Time 0 coordinates should correspond to 0th coordinates');
+  assert.ok(locator.coords(46317).geometry.coordinates[0] < step0lon && locator.coords(46317).geometry.coordinates[0] > step1lon &&
+            locator.coords(46317).geometry.coordinates[1] < step0lat && locator.coords(46317).geometry.coordinates[1] > step1lat, 'Time 46317 coordinates should fall into step 0');
+  assert.ok(Math.abs(locator.coords(46318).geometry.coordinates[0] - step1lon) < 0.00001 &&
+            Math.abs(locator.coords(46318).geometry.coordinates[1] - step1lat) < 0.00001, 'Time 46318 should correspond to 1st coordinates');
+  assert.ok(locator.coords(219140).geometry.coordinates[0] < step1lon && locator.coords(219140).geometry.coordinates[0] > step2lon &&
+            locator.coords(219140).geometry.coordinates[1] < step1lat && locator.coords(219140).geometry.coordinates[1] > step2lat, 'Time 219140 coordinates should fall into step 1');
+  assert.ok(Math.abs(locator.coords(219141).geometry.coordinates[0] - step2lon) < 0.00001 &&
+            Math.abs(locator.coords(219141).geometry.coordinates[1] - step2lat) < 0.00001, 'Time 219141 coordinates should correspond to 2nd coordinates');
+  assert.ok(locator.coords(259743).geometry.coordinates[0] < step2lon && locator.coords(259743).geometry.coordinates[0] > step3lon &&
+            locator.coords(259743).geometry.coordinates[1] < step2lat && locator.coords(259743).geometry.coordinates[1] > step3lat, 'Time 259743 coordinates should fall into step 2');
+  assert.ok(Math.abs(locator.coords(259744).geometry.coordinates[0] - step3lon) < 0.00001 &&
+            Math.abs(locator.coords(259744).geometry.coordinates[1] - step3lat) < 0.00001, 'Time 259744 coordinates should correspond to 3rd coordinates');
   assert.end();
 });

--- a/test/locator.test.js
+++ b/test/locator.test.js
@@ -21,7 +21,7 @@ test('maneuvers v4', function (assert) {
     assert.ok(Math.abs(timesExpected[i] - times[i]) < 0.00001, 'Time should fall within reasonable threshold of expected');
     assert.ok(Math.abs(coordinatesExpected[i][0] - coordinates[i][0]) < 0.00001, 'Latitude should fall within reasonable treshold of expected');
     assert.ok(Math.abs(coordinatesExpected[i][1] - coordinates[i][1]) < 0.00001, 'Latitude should fall within reasonable treshold of expected');
-  };
+  }
   assert.end();
 });
 
@@ -44,7 +44,7 @@ test('maneuvers v5', function (assert) {
     assert.ok(Math.abs(timesExpected[i] - times[i]) < 0.00001, 'Time should fall within reasonable threshold of expected');
     assert.ok(Math.abs(coordinatesExpected[i][0] - coordinates[i][0]) < 0.00001, 'Latitude should fall within reasonable treshold of expected');
     assert.ok(Math.abs(coordinatesExpected[i][1] - coordinates[i][1]) < 0.00001, 'Latitude should fall within reasonable treshold of expected');
-  };
+  }
   assert.end();
 });
 
@@ -67,7 +67,7 @@ test('maneuvers v5 in acceldecel mode', function (assert) {
     assert.ok(Math.abs(timesExpected[i] - times[i]) < 0.00001, 'Time should fall within reasonable threshold of expected');
     assert.ok(Math.abs(coordinatesExpected[i][0] - coordinates[i][0]) < 0.00001, 'Latitude should fall within reasonable treshold of expected');
     assert.ok(Math.abs(coordinatesExpected[i][1] - coordinates[i][1]) < 0.00001, 'Latitude should fall within reasonable treshold of expected');
-  };
+  }
   assert.end();
 });
 

--- a/test/locator.test.js
+++ b/test/locator.test.js
@@ -1,6 +1,76 @@
 var Locator = require('../lib/locator');
 var test = require('tape');
 
+test('maneuvers v4', function (assert) {
+  var geojson = JSON.parse(JSON.stringify(require('./fixtures/rmnp.v4.json')));
+  var locator = new Locator(geojson);
+  var timesExpected = [ 0, 5000, 47000, 197000, 243000 ];
+  var coordinatesExpected = [
+    [ -105.58171, 40.366241 ],
+    [ -105.581888, 40.36608 ],
+    [ -105.585087, 40.365885 ],
+    [ -105.585769, 40.358648 ],
+    [ -105.590118, 40.358022 ]
+  ];
+  var times = locator.maneuvers().times;
+  var coordinates = locator.maneuvers().coordinates;
+  var length = times.length;
+
+  assert.equal(times.length, coordinates.length, 'Times and coordinates array lengths should be equal');
+  for (var i = 0; i < length; i++) {
+    assert.ok(Math.abs(timesExpected[i] - times[i]) < 0.00001, 'Time should fall within reasonable threshold of expected');
+    assert.ok(Math.abs(coordinatesExpected[i][0] - coordinates[i][0]) < 0.00001, 'Latitude should fall within reasonable treshold of expected');
+    assert.ok(Math.abs(coordinatesExpected[i][1] - coordinates[i][1]) < 0.00001, 'Latitude should fall within reasonable treshold of expected');
+  };
+  assert.end();
+});
+
+test('maneuvers v5', function (assert) {
+  var geojson = JSON.parse(JSON.stringify(require('./fixtures/rmnp.v5.json')));
+  var locator = new Locator(geojson);
+  var timesExpected = [ 0, 47900, 220700, 257400 ];
+  var coordinatesExpected = [
+    [ -105.581675, 40.366194 ],
+    [ -105.585075, 40.365892 ],
+    [ -105.586052, 40.358819 ],
+    [ -105.590121, 40.358023 ]
+  ];
+  var times = locator.maneuvers().times;
+  var coordinates = locator.maneuvers().coordinates;
+  var length = times.length;
+
+  assert.equal(times.length, coordinates.length, 'Times and coordinates array lengths should be equal');
+  for (var i = 0; i < length; i++) {
+    assert.ok(Math.abs(timesExpected[i] - times[i]) < 0.00001, 'Time should fall within reasonable threshold of expected');
+    assert.ok(Math.abs(coordinatesExpected[i][0] - coordinates[i][0]) < 0.00001, 'Latitude should fall within reasonable treshold of expected');
+    assert.ok(Math.abs(coordinatesExpected[i][1] - coordinates[i][1]) < 0.00001, 'Latitude should fall within reasonable treshold of expected');
+  };
+  assert.end();
+});
+
+test('maneuvers v5 in acceldecel mode', function (assert) {
+  var geojson = JSON.parse(JSON.stringify(require('./fixtures/rmnp.v5.json')));
+  var locator = new Locator(geojson, {'spacing': 'acceldecel'});
+  var timesExpected = [ 0, 46318, 219141, 259744 ];
+  var coordinatesExpected = [
+    [ -105.581675, 40.366194 ],
+    [ -105.585075, 40.365892 ],
+    [ -105.586052, 40.358819 ],
+    [ -105.590121, 40.358023 ]
+  ];
+  var times = locator.maneuvers().times;
+  var coordinates = locator.maneuvers().coordinates;
+  var length = times.length;
+
+  assert.equal(times.length, coordinates.length, 'Times and coordinates array lengths should be equal');
+  for (var i = 0; i < length; i++) {
+    assert.ok(Math.abs(timesExpected[i] - times[i]) < 0.00001, 'Time should fall within reasonable threshold of expected');
+    assert.ok(Math.abs(coordinatesExpected[i][0] - coordinates[i][0]) < 0.00001, 'Latitude should fall within reasonable treshold of expected');
+    assert.ok(Math.abs(coordinatesExpected[i][1] - coordinates[i][1]) < 0.00001, 'Latitude should fall within reasonable treshold of expected');
+  };
+  assert.end();
+});
+
 test('step v4', function (assert) {
   var geojson = JSON.parse(JSON.stringify(require('./fixtures/rmnp.v4.json')));
   var locator = new Locator(geojson);

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -90,7 +90,7 @@ test('route', function(t) {
     ];
     var expectedTimes = [ 41791, 42525, 44245, 46318 ];
  
-    var firstStep = interpolateAccelDecel(firstThree, 5)[0];
+    var firstStep = interpolateAccelDecel(firstThree)[0];
     assert.deepEqual(firstStep.geometry.coordinates.splice(-4), expectedCoords);
     assert.deepEqual(firstStep.properties.coordinateProperties.times.splice(-4), expectedTimes);
 
@@ -347,7 +347,7 @@ test('interpolateAccelDecel', function(t) {
   var garageSteps = garage.routes[0].legs[0].steps;
 
   t.test('garage - steps', function(assert) {
-    var steps = interpolateAccelDecel(garageSteps, 5);
+    var steps = interpolateAccelDecel(garageSteps);
     var expected = require('./expected/garage-acceldecel-steps.json');
     assert.deepEqual(steps, expected);
     assert.end();
@@ -440,7 +440,7 @@ test('interpolateAccelDecel [synthetic]', function(assert) {
     }
   ];
 
-  var interpolated = interpolateAccelDecel(input, 5);
+  var interpolated = interpolateAccelDecel(input);
   assert.deepEqual(
     interpolated[0].geometry.coordinates[0],
     input[0].geometry.coordinates[0],


### PR DESCRIPTION
Refs [issue #8](https://github.com/mapbox/guidance-replay/issues/8)

This PR tracks the addition of:
- Better locator handling when `{"spacing": "acceldecel"}`, specifically in modifying the times at which maneuvers are expected to occur
- Tests for `{"spacing": "acceldecdel"}` mode

@emilymcafee @yhahn can I borrow your 👀?
